### PR TITLE
Sancus-main compatibility with recent compiler and core changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ debian-deps:
 # Python3 PIP packages
 pip-deps: debian-deps
 	$(info .. Installing system-wide Python3 PIP packages)
-	python3 -m pip install pyelftools \
+	python3 -m pip install pyelftools pyyaml \
           && printf "import elftools\nprint(elftools)" | python3
 	touch pip-deps
 


### PR DESCRIPTION
This PR will make sure sancus-main works with the recent changes made to sancus-compiler (https://github.com/sancus-tee/sancus-compiler/pull/33 ) and sancus-core (https://github.com/sancus-tee/sancus-core/pull/24 )